### PR TITLE
Feature/service refactor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,10 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+[*.js]
+indent_style = space
+indent_size = 2
+
 [*.hbs]
 insert_final_newline = false
 

--- a/addon/adapters/horizon.js
+++ b/addon/adapters/horizon.js
@@ -6,7 +6,10 @@ const { RSVP: {Promise}, get, inject: {service}, typeOf } = Ember;
 /**
  * @class HorizonAdapter
  *
- * This adapter uses Horizon's fetch (non-streaming) interface.
+ * This adapter integrates with a Horizon/RethinkDB stack; it provides
+ * normal CRUD operations by default and can provide real-time updates
+ * if the application chooses to use the services "watch" services for one,
+ * many, or all collections.
  */
 export default Adapter.extend({
     horizon: service(),

--- a/addon/services/horizon.js
+++ b/addon/services/horizon.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+});

--- a/addon/services/horizon.js
+++ b/addon/services/horizon.js
@@ -1,8 +1,13 @@
 import Ember from 'ember';
-import horizon from 'npm:@horizon/client/dist/horizon';
 import config from 'ember-get-config';
+import horizon from 'npm:@horizon/client/dist/horizon';
 
-const { RSVP: {Promise}, debug, get } = Ember;
+// The horizon object with configuration from users ENV
+const hzConfig = config.horizon || {};
+const hz = horizon(hzConfig);
+
+const { RSVP: {Promise}, debug, get, typeOf } = Ember;
+const a = Ember.A;
 
 /**
  * @class Horizon
@@ -11,52 +16,114 @@ const { RSVP: {Promise}, debug, get } = Ember;
  */
 export default Ember.Service.extend({
   init() {
-    this._super() {
-      this._super(...arguments);
-      this._connections = [];
-      this._subscriptions = [];
-    }
+    this._super(...arguments);
+    this._collections = []; // TODO: check whether Horizon does collection caching for you
+    this._subscriptions = [];
+    this._watching = [];
   },
+  willDestroyElement() {
+    this._watching.forEach(s => s.unsubscribe());
+    this._subscriptions.forEach(s => s.unsubscribe()); // TODO: understand lifecycle better
+    hz.disconnect();
+  },
+
+  currentUser: null,  // set by Horizon Observable
+  status: 'init',     // set by Horizon Observable
+  hasAuthToken: null, // set by Horizon Observable
+  raw: false,         // Horizon default; specifies detail/structure in watched changes
 
   connect() {
     return new Promise((resolve, reject) => {
 
-      const h = horizon();
       const status = get(this, 'status');
       if(status === 'connected') {
         resolve();
       } else {
-        h.connect();
-        h.onReady(() => {
+        hz.connect();
+        hz.onReady(() => {
+          this._statusObservable();
+          this._currentUserObservable();
           debug('horizon client connected to backend');
           resolve();
         });
-        h.onDisconnected(() => {
+        hz.onDisconnected(() => {
           this._disconnected();
-          reject({code: 'disconnected'});
+          reject({code: 'disconnected', config: hz});
         });
-        h.onSocketError(() => {
+        hz.onSocketError(() => {
           this._socketError();
           reject({code: 'socket-error'});
         });
       }
 
     }); // return promise
+  },
 
-    collection(collection) {
-      return new Promise((resolve, reject) => {
+  collection(collection) {
+    const c = typeOf(collection) === 'string' ? collection : collection.modelName;
+    return new Promise((resolve, reject) => {
 
       this.connect()
         .then(() => {
-          if(!this._collections[collection]) {
-            const horizon = window.Horizon();
-            this._collections[collection] = horizon(collection);
+          if(!this._collections[c]) {
+            this._collections[c] = hz(collection);
           }
-          resolve(this._collections[collection]);
+          resolve(this._collections[c]);
         })
         .catch(reject);
 
-      }); // return promise
+    }); // return promise
+  },
+
+  /**
+   * Sets up a RethinkDB changestream which can be scoped against
+   * a whole collection, a query, or a singular document. When an update
+   * is detected the callback will be fired
+   *
+   * @param  {String}   collection the name of the collection to scope the changestream to
+   * @param  {Object}   options    additional options parameters include "query" and "id" to further scope stream
+   *                               you can also state "raw" (boolean) which states whether Horizon should process
+   *                               the change and just return the full results set (raw=false) or the stream's
+   *                               change document should be sent back (raw=true).
+   * @return {Observable}          RxJS observable object
+   */
+  watch(collection, options = {}) {
+    // TODO: implment
+  },
+
+  /**
+   * Allows the execution of a Collection.find primative,
+   * returning a chainable Collection object
+   *
+   * @param  {[type]} collection [description]
+   * @param  {[type]} filterBy   [description]
+   * @return {[type]}            [description]
+   */
+  find(collection, filterBy) {
+    if (filterBy) {
+      return Promise.resolve(collection.find(filterBy));
+    } else {
+      return Promise.reject({code: "find-requires-filter-by"});
     }
-  }
+  },
+
+  findAll(collection, filterBy) {
+
+  },
+
+
+
+
+  _statusObservable() {
+    hz.status().watch().subscribe( status => {
+      this.set('status', status);
+    });
+  },
+  _currentUserObservable() {
+    hz.currentUser().watch().subscribe( user => {
+      this.set('currentUser', user);
+    });
+  },
+
+
 });

--- a/addon/services/horizon.js
+++ b/addon/services/horizon.js
@@ -43,7 +43,7 @@ export default Ember.Service.extend({
         hz.onReady(() => {
           this._statusObservable();
           this._currentUserObservable();
-          debug('horizon client connected to backend');
+          debug('horizon client connected');
           resolve();
         });
         hz.onDisconnected(() => {

--- a/addon/services/horizon.js
+++ b/addon/services/horizon.js
@@ -3,6 +3,8 @@ import config from 'ember-get-config';
 import horizon from 'npm:@horizon/client/dist/horizon';
 
 // The horizon object with configuration from users ENV
+// Note: often the DEV environment will be left blank
+// and rather than just let it
 const hzConfig = config.horizon || {};
 const hz = horizon(hzConfig);
 

--- a/addon/services/horizon.js
+++ b/addon/services/horizon.js
@@ -1,4 +1,62 @@
 import Ember from 'ember';
+import horizon from 'npm:@horizon/client/dist/horizon';
+import config from 'ember-get-config';
 
+const { RSVP: {Promise}, debug, get } = Ember;
+
+/**
+ * @class Horizon
+ *
+ * Service methods for interacting with Horizon
+ */
 export default Ember.Service.extend({
+  init() {
+    this._super() {
+      this._super(...arguments);
+      this._connections = [];
+      this._subscriptions = [];
+    }
+  },
+
+  connect() {
+    return new Promise((resolve, reject) => {
+
+      const h = horizon();
+      const status = get(this, 'status');
+      if(status === 'connected') {
+        resolve();
+      } else {
+        h.connect();
+        h.onReady(() => {
+          debug('horizon client connected to backend');
+          resolve();
+        });
+        h.onDisconnected(() => {
+          this._disconnected();
+          reject({code: 'disconnected'});
+        });
+        h.onSocketError(() => {
+          this._socketError();
+          reject({code: 'socket-error'});
+        });
+      }
+
+    }); // return promise
+
+    collection(collection) {
+      return new Promise((resolve, reject) => {
+
+      this.connect()
+        .then(() => {
+          if(!this._collections[collection]) {
+            const horizon = window.Horizon();
+            this._collections[collection] = horizon(collection);
+          }
+          resolve(this._collections[collection]);
+        })
+        .catch(reject);
+
+      }); // return promise
+    }
+  }
 });

--- a/app/services/horizon.js
+++ b/app/services/horizon.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-horizon/services/horizon';

--- a/blueprints/ember-cli-horizon/index.js
+++ b/blueprints/ember-cli-horizon/index.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 module.exports = {
-  description: 'Default blueprint to be run after install.',
+  description: 'ember-cli-horizon blueprint',
   normalizeEntityName: function() {
     // this prevents an error when the entityName is not specified
 	},
@@ -10,6 +10,15 @@ module.exports = {
       { name: 'bufferutil', target: '^1.2.1'  },
       { name: 'utf-8-validate', target: '^1.2.1' },
       { name: 'ember-browserify', target: '^1.1.9' }
-    ]);
-  }
+    ]).then(function() {
+      console.log(chalk.green.bold('ember-cli-horizon') + ' has been installed.');
+      console.log('  - in order to use this you will need to install the Horizon server,');
+      console.log('    you can find more information here: ' + chalk.blue.underline('http://horizon.io/install/'));
+      console.log();
+      console.log('In development mode you can serve both Horizon server and Ember\'s "serve" by');
+      console.log('using the ' + chalk.bold('ember horizon:serve') + ' command.');
+      console.log();
+      return Promise.resolve();
+    });
+  },
 };

--- a/blueprints/ember-cli-horizon/index.js
+++ b/blueprints/ember-cli-horizon/index.js
@@ -1,13 +1,15 @@
 /*jshint node:true*/
 module.exports = {
     description: 'Default blueprint to be run after install.',
-
+    normalizeEntityName: function() {
+		// this prevents an error when the entityName is not specified
+	},
     afterInstall: function() {
         return this.addPackagesToProject([
-            { package: '@horizon/client' },
-            { package: 'bufferutil' },
-            { package: 'utf-8-validate' },
-            { package: 'ember-browserify' }
+            { name: '@horizon/client', target: '^1.1.1' },
+            { name: 'bufferutil', target: '^1.2.1'  },
+            { name: 'utf-8-validate', target: '^1.2.1' },
+            { name: 'ember-browserify', target: '^1.1.9' }
         ]);
     }
 };

--- a/blueprints/ember-cli-horizon/index.js
+++ b/blueprints/ember-cli-horizon/index.js
@@ -1,15 +1,15 @@
 /*jshint node:true*/
 module.exports = {
-    description: 'Default blueprint to be run after install.',
-    normalizeEntityName: function() {
-		// this prevents an error when the entityName is not specified
+  description: 'Default blueprint to be run after install.',
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is not specified
 	},
-    afterInstall: function() {
-        return this.addPackagesToProject([
-            { name: '@horizon/client', target: '^1.1.1' },
-            { name: 'bufferutil', target: '^1.2.1'  },
-            { name: 'utf-8-validate', target: '^1.2.1' },
-            { name: 'ember-browserify', target: '^1.1.9' }
-        ]);
-    }
+  afterInstall: function() {
+    return this.addPackagesToProject([
+      { name: '@horizon/client', target: '^1.1.1' },
+      { name: 'bufferutil', target: '^1.2.1'  },
+      { name: 'utf-8-validate', target: '^1.2.1' },
+      { name: 'ember-browserify', target: '^1.1.9' }
+    ]);
+  }
 };

--- a/blueprints/ember-cli-horizon/index.js
+++ b/blueprints/ember-cli-horizon/index.js
@@ -1,5 +1,6 @@
 /*jshint node:true*/
 var chalk = require('chalk');
+var RSVP = require('rsvp');
 
 module.exports = {
   description: 'ember-cli-horizon blueprint',
@@ -7,20 +8,27 @@ module.exports = {
     // this prevents an error when the entityName is not specified
 	},
   afterInstall: function() {
-    return this.addPackagesToProject([
-      { name: '@horizon/client', target: '^1.1.1' },
-      { name: 'bufferutil', target: '^1.2.1'  },
-      { name: 'utf-8-validate', target: '^1.2.1' },
-      { name: 'ember-browserify', target: '^1.1.9' }
-    ]).then(function() {
-      console.log(chalk.green.bold('ember-cli-horizon') + ' has been installed.');
-      console.log('  - in order to use this you will need to install the Horizon server,');
-      console.log('    you can find more information here: ' + chalk.blue.underline('http://horizon.io/install/'));
-      console.log();
-      console.log('In development mode you can serve both Horizon server and Ember\'s "serve" by');
-      console.log('using the ' + chalk.bold('ember horizon:serve') + ' command.');
-      console.log();
-      return Promise.resolve();
+    var self = this;
+    return new RSVP.Promise(function(resolve, reject) {
+
+      self.addPackagesToProject([
+          { name: '@horizon/client', target: '^1.1.1' },
+          { name: 'bufferutil', target: '^1.2.1'  },
+          { name: 'utf-8-validate', target: '^1.2.1' },
+          { name: 'ember-browserify', target: '^1.1.9' }
+      ])
+        .then(function() {
+          console.log(chalk.green.bold('ember-cli-horizon') + ' has been installed along with all client dependencies.');
+          console.log('  - in order to use this you will need to install the Horizon server,');
+          console.log('    you can find more information here: ' + chalk.blue.underline('http://horizon.io/install/'));
+          console.log();
+          console.log('In development mode you can serve both Horizon server and Ember\'s "serve" by');
+          console.log('using the ' + chalk.bold('ember horizon:serve') + ' command.');
+          console.log();
+          resolve(true);
+        })
+        .catch(reject);
+
     });
   },
 };

--- a/blueprints/ember-cli-horizon/index.js
+++ b/blueprints/ember-cli-horizon/index.js
@@ -1,4 +1,6 @@
 /*jshint node:true*/
+var chalk = require('chalk');
+
 module.exports = {
   description: 'ember-cli-horizon blueprint',
   normalizeEntityName: function() {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 /* jshint node: true */
 'use strict';
 
+var commands = require('./lib/commands');
+
 module.exports = {
-  name: 'ember-cli-horizon'
+  name: 'ember-cli-horizon',
+  includedCommands: function() {
+    return commands;
+  },
 };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,0 +1,5 @@
+/* jshint node: true */
+
+module.exports = {
+  'horizon:serve':   require('./serve'),
+};

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,0 +1,19 @@
+/* jshint node: true */
+'use strict';
+
+module.exports = {
+  name: 'horizon:serve',
+  aliases: ['h:s'],
+  description: 'Serve both Ember, Horizon server, and ReThinkDB.',
+  works: 'insideProject',
+
+  availableOptions: [
+    { name: 'env', type: String, default: 'development' },
+    { name: 'port', type: String, default: '4200' },
+    { name: 'debug', type: Boolean, default: false },
+  ],
+
+  run: function(options) {
+    return require('../tasks/serve')(options.port, options.debug)();
+  }
+};

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -1,0 +1,32 @@
+/* jshint node: true */
+'use strict';
+
+var runCommand = require('../utils/run-command');
+var path       = require('path');
+var linkEnv    = require('../tasks/link-environment');
+
+module.exports = function(env, port, debug) {
+  // REF: https://github.com/poetic/ember-cli-cordova/blob/v0.0.14/lib/tasks/build.js
+
+  // var emberCommand = 'ember build --environment ' + env;
+  //
+  // var emberMsg   = 'Building ember project for environment ' + env;
+  // var emberBuild = runCommand(emberCommand, emberMsg, {
+  //   cwd: project.root
+  // });
+  //
+  // var cdvCommand = 'cordova build ' + platform;
+  //
+  // if (env !== 'development') {
+  //   cdvCommand += ' --release';
+  // }
+  //
+  // var cdvMsg   = 'Building cordova project for platform ' + platform;
+  // var cdvBuild = runCommand(cdvCommand, cdvMsg, {
+  //   cwd: path.join(project.root, 'cordova')
+  // });
+  //
+  // return function(){
+  //   return linkEnv(project)().then(emberBuild).then(cdvBuild);
+  // };
+};

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -6,6 +6,7 @@ var path       = require('path');
 var linkEnv    = require('../tasks/link-environment');
 
 module.exports = function(env, port, debug) {
+  return;
   // REF: https://github.com/poetic/ember-cli-cordova/blob/v0.0.14/lib/tasks/build.js
 
   // var emberCommand = 'ember build --environment ' + env;

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -1,0 +1,54 @@
+/* jshint node: true */
+'use strict';
+
+var RSVP     = require('rsvp');
+var Promise  = RSVP.Promise;
+var exec     = require('child_process').exec;
+var chalk    = require('chalk');
+var ui       = require('../ui');
+var defaults = require('lodash').defaults;
+
+module.exports = function runCommand(command, startedMsg, options) {
+  if(options == null) {
+    options = {}
+  }
+
+  return function() {
+    if(startedMsg) {
+      ui.start(chalk.green(startedMsg));
+    }
+
+    options = defaults(options, {
+      maxBuffer: 5000 * 1024
+    });
+
+    return new Promise(function(resolve, reject) {
+      exec(command, options, function(err, stdout, stderr) {
+        ui.write('\n');
+
+        if (stdout && stdout.length) {
+          ui.write(stdout);
+        }
+
+        if (stderr && stderr.length) {
+          ui.write(stderr);
+        }
+
+        if (err) {
+          return reject(commandError(command, err));
+        }
+
+        resolve(stdout);
+      });
+    });
+  };
+};
+
+function commandError(command, err) {
+  ui.write(chalk.red('\nError thrown while running shell command: "' + command + '"\n'));
+  if(err.stack) {
+    ui.write(err.stack);
+  } else {
+    ui.write(err);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-horizon",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An Ember service for managing a Horizon connection, and an adapter to request data from that connection.",
   "directories": {
     "doc": "doc",
@@ -56,6 +56,7 @@
     "ember-data-adapter"
   ],
   "dependencies": {
+    "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,20 @@
   "engines": {
     "node": ">= 0.10.0"
   },
+  "files": [
+    "ember-cli-build.js",
+    "LICENSE.md",
+    "README.md",
+    "addon",
+    "blueprints",
+    "app",
+    "lib",
+    "bower.json",
+    "index.js",
+    "package.json",
+    "testem.json",
+    "vendor"
+  ],
   "author": "Kyle Jones <kyle@jonesetc.com>",
   "license": "MIT",
   "devDependencies": {

--- a/tests/unit/services/horizon-test.js
+++ b/tests/unit/services/horizon-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:horizon', 'Unit | Service | horizon', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
This is still a rough draft but hopefully easy enough to read. Here are the main bullets:
- Change the _service_ to just be called `horizon` and allow it to abstract all aspects of Horizon
  - this means Adapter only interacts with the service
  - also better enables a future scenario where we're using a different middleware combo
  - allows for other consumers besides the Ember-data adapter (I'd like to see at some point easy integration with `ember-redux`)
- The adapter is very similar but it's main design difference is that all "GET" oriented operations will check to see if the table is being watched and if it is will revert to a `peek` based ED command (assumption being the table is already up-to-date). 
